### PR TITLE
Add GitHub pages support using karumi template

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Gradle plugin to enable build configuration secrets for Kotlin, Kotlin-Native / 
 
 Add our Gradle Plugin to your build.gradle file:
 
-```
+```groovy
 buildscript {
     repositories {
         mavenCentral()
@@ -30,7 +30,7 @@ kotlin.sourceSets["main"].kotlin.srcDirs("$buildDir/generated/kotlin/config")
 
 Use `gradle.properties` file to add the key-value configuration you want like this:
 
-```
+```groovy
 api_key = "some_api_key"
 number_key = 11
 ```
@@ -39,7 +39,7 @@ number_key = 11
 
 First you must build your project, `./gradlew build`, it generates the HaguConfig kotlin object with the property constants you added in `gradle.properties`.
 
-```
+```kotlin
 import com.karumi.hagu.generated.HaguConfig
 
 println(HaguConfig.API_KEY)  //output: some_api_key

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: "Hagu"
+baseurl: /Hagu
+remote_theme: Karumi/KarumiJekyllTheme


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #7 

### :tophat: What is the goal

Configure the repository to have a GitHub page pointing at ``master`` using the official Karumi Jekyll template. To be able to use our own domain I need @davideme to create the domain ``hagu.karumi.com``. Please @davideme if you could do this next week we could send another PR adjusting the theme configured if needed and providing the ``CNAME`` configuartion we need.

I've also updated the project readme with some metadata useful to render the code with a better syntax highlighting.

### How is it being implemented?

To implement this, we've first enabled GitHub pages support and then we've added the ``_config.yml`` file needed to configure our own theme.

### How can it be tested?

You can change the branch used to create the GitHub page, point at this one and check [this url](https://karumi.github.io/Hagu/) out. If you do this, remember to reset the pages configuration to the previous state.